### PR TITLE
Prevent JavaScript error from HB formatting

### DIFF
--- a/assets/javascripts/discourse/templates/components/google-dfp-ad.hbs
+++ b/assets/javascripts/discourse/templates/components/google-dfp-ad.hbs
@@ -2,7 +2,8 @@
 <div id='{{divId}}' style='{{fixedSize}}' class="dfp-ad-unit">
   {{#if loadedGoogletag}}
     <script type='text/javascript'>
-      googletag.cmd.push(function() { googletag.display('{{divId}}'); });
+      var divId = document.currentScript.parentNode.id;
+      googletag.cmd.push(function() { googletag.display(divId); });
     </script>
   {{/if}}
 </div>


### PR DESCRIPTION
When Handlebars substitues {{params}} it adds a line-break before and after which results in malformed JavaScript:

```
'
  i-love-linebreaks
     '
```

Uncaught SyntaxError: Invalid or unexpected token
    at TreeConstruction.insertBefore (index.ts:8)
    at ElementStack.appendText (index.ts:8)
    at TextOpcode.evaluate (index.ts:8)
    at VM.execute (index.ts:8)
    at VM.resume (index.ts:8)
    at TryOpcode.handleException (index.ts:8)
    at UpdatingVMFrame.handleException (index.ts:8)
    at UpdatingVM._throw [as throw] (index.ts:8)
    at Assert.evaluate (index.ts:8)
    at UpdatingVM.execute (index.ts:8)