### PR TITLE
Ignore auto_generated directory contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ config/secrets.yml
 ## Environment normalisation:
 /.bundle
 /vendor/bundle
+/auto_generated/
 
 # these should all be checked in to normalise the environment:
 # Gemfile.lock, .ruby-version, .ruby-gemset


### PR DESCRIPTION
Update `.gitignore` to have `/auto_generated/` ignored so as to prevent git complaining about a dirty submodule in dev.